### PR TITLE
Update FormField.jsx - Eye icon toggle needs to be reversed

### DIFF
--- a/components/FormField.jsx
+++ b/components/FormField.jsx
@@ -31,7 +31,7 @@ const FormField = ({
         {title === "Password" && (
           <TouchableOpacity onPress={() => setShowPassword(!showPassword)}>
             <Image
-              source={!showPassword ? icons.eye : icons.eyeHide}
+              source={!showPassword ? icons.eyeHide : icons.eye}
               className="w-6 h-6"
               resizeMode="contain"
             />


### PR DESCRIPTION
It was set to eye when the password was not visible and eyeHide when it was. I reversed the icons to make it function as intended.