### PR TITLE
Fixed error in FlatList by memoizing viewableItemsChanged with useCallback

### DIFF
--- a/components/Trending.jsx
+++ b/components/Trending.jsx
@@ -82,7 +82,7 @@ const Trending = ({ posts }) => {
     if (viewableItems.length > 0) {
       setActiveItem(viewableItems[0].key);
     }
-  });
+  },[]);
 
   return (
     <FlatList

--- a/components/Trending.jsx
+++ b/components/Trending.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ResizeMode, Video } from "expo-av";
 import * as Animatable from "react-native-animatable";
 import {
@@ -78,11 +78,11 @@ const TrendingItem = ({ activeItem, item }) => {
 const Trending = ({ posts }) => {
   const [activeItem, setActiveItem] = useState(posts[0]);
 
-  const viewableItemsChanged = ({ viewableItems }) => {
+  const viewableItemsChanged = useCallback(({ viewableItems }) => {
     if (viewableItems.length > 0) {
       setActiveItem(viewableItems[0].key);
     }
-  };
+  });
 
   return (
     <FlatList


### PR DESCRIPTION
The FlatList internally uses the function reference (onViewableItemsChanged) to track changes. If the reference changes on every render (as it does without useCallback), FlatList will treat it as a completely different function, leading to errors or unexpected behavior. The error message ("Changing onViewableItemsChanged on the fly is not supported") arises because the FlatList does not support dynamically replacing the function during its lifecycle.